### PR TITLE
Fix skipped count on DB CSV import failures

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -927,6 +927,7 @@ export class DatabaseStorage implements IStorage {
         successCount++;
       } catch (error) {
         console.error(`Error importing item: ${JSON.stringify(item)}`, error);
+        skippedCount++;
       }
     }
     


### PR DESCRIPTION
## Summary
- increment `skippedCount` in `DatabaseStorage.importFromCSV` when a record fails

## Testing
- `npm run check` *(fails: cannot find type definition file for 'node')*